### PR TITLE
fix links so that they work with ipfs

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { BrowserRouter as Router, Switch, Route, NavLink, Redirect } from "react-router-dom";
+import { HashRouter as Router, Switch, Route, NavLink, Redirect } from "react-router-dom";
 import './App.css';
 import Web3 from 'web3'
 import Web3Modal from "web3modal";


### PR DESCRIPTION
IPFS gets confused when you try to handle routes the normal way. The simple fix for this is to use react-router's `HashRouter` instead of `BrowserRouter` which converts a route such as `/route` to `/#/route` which will not conflict with IPFS.